### PR TITLE
Using a more simple regex and fix list-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test shfmt https://github.com/luizm/asdf-shfmt.git
+script: asdf plugin-test shfmt https://github.com/luizm/asdf-shfmt.git 'shfmt --version'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - source asdf/asdf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test shfmt https://github.com/luizm/asdf-shfmt.git 'shfmt --version'
+script: asdf plugin-test shfmt https://github.com/luizm/asdf-shfmt.git
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - source asdf/asdf.sh

--- a/bin/list-all
+++ b/bin/list-all
@@ -13,7 +13,10 @@ sort_versions() {
 		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-eval "$cmd" |
-	grep -oE "tag_name\": *\".{1,15}\"," |
-	sed 's/tag_name\": *\"v//;s/\",//' |
-	sort_versions
+# shellcheck disable=SC2046,SC2005
+echo $(
+	eval "$cmd" |
+		grep -oE 'tag_name": *"[^"]*?",' |
+		sed -e 's|^tag_name" *: *"||' -e 's|",||' -e 's|^v||' |
+		sort_versions
+)


### PR DESCRIPTION
before:
```
❯ asdf list-all shfmt
0.1.0
```

after:
```
❯ asdf list-all shfmt
0.1.0
0.2.0
0.3.0
0.4.0
0.5.0
0.6.0
1.0.0
1.1.0
1.2.0
1.3.0
1.3.1
2.0.0
2.0-beta1
2.1.0
2.2.0
2.2.1
2.3.0
2.4.0
2.5.0
2.5.1
2.6.0
2.6.1
2.6.2
2.6.3
2.6.4
```