### PR TITLE
Add multi-arch support (arm, arm64, 386, amd64)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -39,7 +39,6 @@ _get_download_url() {
 }
 
 install() {
-	# local -r install_type=$1 #unused variable
 	local -r version=$2
 	local -r install_path=$3
 	local -r bin_install_path="$install_path/bin"
@@ -54,4 +53,4 @@ install() {
 	chmod +x "$bin_path"
 }
 
-install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -14,23 +14,38 @@ test -n "$ASDF_INSTALL_PATH" || {
 }
 
 _get_arch() {
+  local arch; arch=$(uname -m)
+  case $arch in
+    armv*) arch="arm";;
+    aarch64) arch="arm64";;
+    x86) arch="386";;
+    x86_64) arch="amd64";;
+    i686) arch="386";;
+    i386) arch="386";;
+  esac
+  echo "$arch"
+}
+
+_get_platform() {
 	uname | tr '[:upper:]' '[:lower:]'
 }
 
 _get_download_url() {
 	local -r version="$1"
 	local -r platform="$2"
+	local -r arch="$3"
 
-	echo "https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_${platform}_amd64"
+	echo "https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_${platform}_${arch}"
 }
 
 install() {
-	local -r install_type=$1
+	# local -r install_type=$1 #unused variable
 	local -r version=$2
 	local -r install_path=$3
 	local -r bin_install_path="$install_path/bin"
-	local -r platform="$(_get_arch)"
-	local -r download_url="$(_get_download_url "$version" "$platform")"
+	local -r platform="$(_get_platform)"
+	local -r arch="$(_get_arch)"
+	local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
 	local -r bin_path="$bin_install_path/shfmt"
 
 	mkdir -p "$bin_install_path"


### PR DESCRIPTION
The [releases page](https://github.com/mvdan/sh/releases) of this project includes arm/arm64 support so I've modified the install script to detect the host arch before installing the binary.

I have tested it locally on a raspberry pi running ubuntu server 21.04 If there is anything else I can do, please let me know.

```$ asdf plugin add shfmt https://github.com/mathew-fleisch/asdf-shfmt.git
$ asdf install shfmt latest
Downloading shfmt from https://github.com/mvdan/sh/releases/download/v3.3.0/shfmt_v3.3.0_linux_arm64
$ asdf global shfmt latest
$ shfmt --version
v3.3.0